### PR TITLE
feat: make video/audio codec optional in parse/serialize

### DIFF
--- a/fflint/layer1.js
+++ b/fflint/layer1.js
@@ -586,7 +586,7 @@ export function validateNvdecDeint(s) {
  */
 function validateEnum(s, field, id, flag, validValues, label) {
   const val = s[field]
-  if (val === undefined || val === null) return []
+  if (val === undefined || val === null || val === '') return []
   if (validValues.includes(val)) return []
   return [err(id, id, flag,
     `${label} must be one of: ${validValues.join(', ')} (got "${val}")`)]

--- a/fflint/parse.js
+++ b/fflint/parse.js
@@ -48,7 +48,7 @@ function parseTokens(str) {
   const raw = {
     re: false, loop: false, wallclock: false, fflags: [], maxDelay: '', timeout: '', threadQueueSize: '',
     analyzeduration: '', probesize: '', copyts: false,
-    videoEnabled: true, videoCodec: 'copy', hwaccel: '', hwaccelOutputFormat: '',
+    videoEnabled: true, videoCodec: '', hwaccel: '', hwaccelOutputFormat: '',
     inputDecoderCodec: '', gpuIndex: '',
     preset: '', vprofile: '', frameSize: 'original', customFrameSize: '',
     fps: 'original', customFps: '',
@@ -56,7 +56,7 @@ function parseTokens(str) {
     deinterlaceFilter: '', nvdecDeint: '', forcedIdr: false,
     pixFmt: '', level: '', scThreshold: '', bframes: '', refs: '', bsfVideo: 'none',
     fieldOrder: '', colorPrimaries: '', colorTrc: '', colorspace: '',
-    audioEnabled: true, audioCodec: 'copy',
+    audioEnabled: true, audioCodec: '',
     sampleRate: 'original', channels: 'original', audioBitrate: 'default',
     dialnorm: '', bsfAudio: 'none',
     outputFormat: 'mpegts',
@@ -212,8 +212,8 @@ function parseTokens(str) {
             i++
             const base = streamIdx[1]
             const val = tokens[i] || ''
-            if (base === '-c:v' && passedInput && raw.videoCodec === 'copy') raw.videoCodec = val || 'copy'
-            else if (base === '-c:a' && raw.audioCodec === 'copy') raw.audioCodec = val || 'copy'
+            if (base === '-c:v' && passedInput && !raw.videoCodec) raw.videoCodec = val || 'copy'
+            else if (base === '-c:a' && !raw.audioCodec) raw.audioCodec = val || 'copy'
             else if (base === '-b:v' && !raw.bitrate) raw.bitrate = val
             else if (base === '-b:a' && raw.audioBitrate === 'default') raw.audioBitrate = val
             break
@@ -277,7 +277,7 @@ function toFflintState(s) {
 
   if (!s.videoEnabled) {
     f.videoCodec = 'disabled'
-  } else {
+  } else if (s.videoCodec) {
     f.videoCodec = s.videoCodec
     if (s.videoCodec !== 'copy' && s.videoCodec !== 'disabled') {
       if (s.hwaccel) f.hwaccel = s.hwaccel
@@ -336,7 +336,7 @@ function toFflintState(s) {
 
   if (!s.audioEnabled) {
     f.audioCodec = 'disabled'
-  } else {
+  } else if (s.audioCodec) {
     f.audioCodec = s.audioCodec
     if (s.audioCodec !== 'copy' && s.audioCodec !== 'disabled') {
       if (s.sampleRate !== 'original') f.sampleRate = s.sampleRate

--- a/tests/test_parse_serialize.mjs
+++ b/tests/test_parse_serialize.mjs
@@ -542,6 +542,58 @@ console.log('\n\x1b[1m═══ Section 21: serialize() with passthrough flags �
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
+console.log('\n\x1b[1m═══ Section: Optional video/audio codec ═══\x1b[0m')
+// ═══════════════════════════════════════════════════════════════════════════════
+
+{
+  // No -c:v / -c:a in input → codecs should be undefined/empty (FFmpeg picks container default)
+  const s = parse('ffmpeg -y -i ${i} -f mpegts ${o}')
+  assert('no -c:v → videoCodec falsy', !s.videoCodec)
+  assert('no -c:a → audioCodec falsy', !s.audioCodec)
+  assert('videoEnabled stays true', s.videoEnabled !== false)
+  assert('audioEnabled stays true', s.audioEnabled !== false)
+}
+
+{
+  // Round-trip: command without codec args must serialize back without -c:v/-c:a
+  const original = 'ffmpeg -y -i ${i} -f mpegts ${o}'
+  const cmd = serialize(parse(original))
+  assert('no -c:v emitted when not set', !cmd.includes('-c:v'))
+  assert('no -c:a emitted when not set', !cmd.includes('-c:a'))
+  assert('no -vn emitted when not set', !cmd.includes('-vn'))
+  assert('no -an emitted when not set', !cmd.includes('-an'))
+  assert('still has -f mpegts', cmd.includes('-f mpegts'))
+}
+
+{
+  // Validation must NOT error on missing codec
+  const errs = validate(parse('ffmpeg -y -i ${i} -f mpegts ${o}'))
+  const codecErrors = errs.filter(e => e.severity === 'error' && /codec/i.test(e.message || ''))
+  assert('no codec errors when codec absent', codecErrors.length === 0,
+    codecErrors.map(e => e.message).join('; '))
+}
+
+{
+  // Only video codec specified, audio not
+  const s = parse('ffmpeg -y -i ${i} -c:v libx264 -b:v 2M -f mpegts ${o}')
+  assert('videoCodec=libx264', s.videoCodec === 'libx264')
+  assert('audioCodec falsy when -c:a absent', !s.audioCodec)
+  const cmd = serialize(s)
+  assert('serializes -c:v libx264', cmd.includes('-c:v libx264'))
+  assert('does not emit -c:a', !cmd.includes('-c:a'))
+}
+
+{
+  // Only audio codec specified
+  const s = parse('ffmpeg -y -i ${i} -c:a aac -b:a 128k -f mpegts ${o}')
+  assert('audioCodec=aac', s.audioCodec === 'aac')
+  assert('videoCodec falsy when -c:v absent', !s.videoCodec)
+  const cmd = serialize(s)
+  assert('serializes -c:a aac', cmd.includes('-c:a aac'))
+  assert('does not emit -c:v', !cmd.includes('-c:v'))
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
 console.log(`\n\x1b[1m═══ Results: ${pass}/${pass + fail} passed ═══\x1b[0m`)
 if (fail > 0) {
   console.log(`\x1b[31m${fail} test(s) FAILED\x1b[0m`)


### PR DESCRIPTION
## Summary

Make `-c:v` / `-c:a` truly optional in fflint. When a command has no codec flag, `parse()` now leaves `videoCodec`/`audioCodec` empty instead of forcing `'copy'`, and `serialize()` omits the flag so FFmpeg picks the container default codec.

## Behavior

| Command fragment | `videoCodec` |
|---|---|
| `-c:v libx264` | `'libx264'` |
| `-c:v copy` | `'copy'` |
| `-vn` | `'disabled'` (`videoEnabled=false`) |
| *(none)* | `''` — falsy; serialize omits `-c:v` |

Same logic for audio.

## Changes

- **fflint/parse.js**
  - Default `videoCodec` / `audioCodec` is `''` (was `'copy'`).
  - Stream-specifier branch (`-c:v:0` etc.) checks `!raw.videoCodec` (truly unset) instead of `=== 'copy'` (default proxy).
  - `toFflintState` only emits `f.videoCodec` and the encoding-only fields when the codec is explicitly set; `videoEnabled === false` still maps to `'disabled'`.
- **fflint/layer1.js**
  - `validateEnum` also skips empty strings — keeps L1 quiet on unset fields.
- **tests/test_parse_serialize.mjs**
  - New ‘Optional video/audio codec’ section: 18 assertions covering parse, serialize, round-trip and validation when `-c:v`/`-c:a` are absent.

## Test results

- `tests/test_parse_serialize.mjs` — 219/219
- `tests/test_audit.mjs` — 58/58
- `tests/test_audit_v2.mjs` — 97/97
- `tests/test_fixes.mjs` — 10/10
- `tests/test_harden.mjs` — 33/33
- `tests/fflint_test.mjs` — no UNEXPECTED outcomes

## Backwards compatibility

All existing tests use commands with explicit `-c:v` / `-c:a` / `-c copy` and continue to pass unchanged. Only commands that omit the codec flag get the new (correct) behavior.